### PR TITLE
Attack decay

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ import SynthConfig from "./synthConfig.js"
   onOff.addEventListener('click',unmute, false);
   document.getElementById("matrix").appendChild(onOff);        
 
+  let itervalMiliSec = 250; //125 original value
 
   let westernSubdivisions = 12;
   let westernOffsets = [0,3,5,7,10,12,12+3,5+12,7+12,10+12,24,24+3,24+5,24+7,24+10,24+12];
@@ -34,7 +35,7 @@ import SynthConfig from "./synthConfig.js"
   let octave = westernOctave;
 
 
-  let mySynth = new SwitchSynth(rootNote,subdivisions,offsets,octave);
+  let mySynth = new SwitchSynth(rootNote,subdivisions,offsets,octave,itervalMiliSec);
   let mySynthDisplay = new SynthConfig(rootNote,subdivisions,offsets,octave);
 
   let offsetDisplays = [];
@@ -53,7 +54,7 @@ import SynthConfig from "./synthConfig.js"
   let currentIteration = 0;
   let previousIteration = 15; 
 
-  setInterval(eachTick, 125);
+  setInterval(eachTick, itervalMiliSec);
 
   let myGrid = new Grid();
   let buttons = [];
@@ -166,23 +167,23 @@ import SynthConfig from "./synthConfig.js"
     {
       let currentIndex =   buttons[currentIteration].indexOf(button);
       if(button.className != 'matrixButtOff' 
-        &&(
-            buttons[previousIteration][currentIndex].className == 'matrixButtOff' 
-            || mySynth.oscillatorState[currentIndex] == false  
-          )
+        // &&(
+        //     buttons[previousIteration][currentIndex].className == 'matrixButtOff' 
+        //     || mySynth.oscillatorState[currentIndex] == false  
+        //   )
         )
       {
         mySynth.connectSpecificOscillator(currentIndex);
       }
-      else if (button.className == 'matrixButtOff' 
-                && (
-                  buttons[previousIteration][currentIndex].className == 'matrixButtOn' 
-                  || mySynth.oscillatorState[currentIndex] == true  
-                )
-              )
-      {
-        mySynth.disconnectSpecificOscillator(currentIndex);
-      }
+      // else if (button.className == 'matrixButtOff' 
+      //           && (
+      //             buttons[previousIteration][currentIndex].className == 'matrixButtOn' 
+      //             || mySynth.oscillatorState[currentIndex] == true  
+      //           )
+      //         )
+      // {
+      //   mySynth.disconnectSpecificOscillator(currentIndex);
+      // }
     });
   }
 

--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ import SynthConfig from "./synthConfig.js"
   onOff.addEventListener('click',unmute, false);
   document.getElementById("matrix").appendChild(onOff);        
 
-  let itervalMiliSec = 250; //125 original value
+  let itervalMiliSec = 250;
 
   let westernSubdivisions = 12;
   let westernOffsets = [0,3,5,7,10,12,12+3,5+12,7+12,10+12,24,24+3,24+5,24+7,24+10,24+12];
@@ -112,7 +112,6 @@ import SynthConfig from "./synthConfig.js"
     octave = arabOctave;
     mySynth.updateAllConfig(octave,subdivisions,offsets);
     mySynthDisplay.updateDisplays(octave,subdivisions,offsets);
-    //console.log(event);
   }
 
   function bp13Click(event)
@@ -122,8 +121,6 @@ import SynthConfig from "./synthConfig.js"
     octave = bohlenOctave;
     mySynth.updateAllConfig(octave,subdivisions, offsets);
     mySynthDisplay.updateDisplays(octave,subdivisions,offsets);
-
-    //console.log(event);
   }
 
   function western12Click(event)
@@ -133,9 +130,6 @@ import SynthConfig from "./synthConfig.js"
     offsets = westernOffsets;
     mySynth.updateAllConfig(octave,subdivisions, offsets);
     mySynthDisplay.updateDisplays(octave,subdivisions,offsets);
-
-  
-    //console.log(event);
   }
 
   function updateOffsetNote(event)
@@ -166,24 +160,10 @@ import SynthConfig from "./synthConfig.js"
     buttons[currentIteration].forEach(button => 
     {
       let currentIndex =   buttons[currentIteration].indexOf(button);
-      if(button.className != 'matrixButtOff' 
-        // &&(
-        //     buttons[previousIteration][currentIndex].className == 'matrixButtOff' 
-        //     || mySynth.oscillatorState[currentIndex] == false  
-        //   )
-        )
+      if(button.className != 'matrixButtOff')
       {
         mySynth.connectSpecificOscillator(currentIndex);
       }
-      // else if (button.className == 'matrixButtOff' 
-      //           && (
-      //             buttons[previousIteration][currentIndex].className == 'matrixButtOn' 
-      //             || mySynth.oscillatorState[currentIndex] == true  
-      //           )
-      //         )
-      // {
-      //   mySynth.disconnectSpecificOscillator(currentIndex);
-      // }
     });
   }
 

--- a/switchSynth.js
+++ b/switchSynth.js
@@ -39,21 +39,6 @@ export default class SwitchSynth
         for(let i = 0; i<16 ; i++)
         {
           let currentOsc = this.audioCtx.createOscillator();
-          //const gainNode = audioCtx.createGain(); // todo.... this stuff
-          // https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Advanced_techniques#the_final_playsweep_function
-          /**
-           * 
-           *    const sweepEnv = new GainNode(audioCtx);
-                sweepEnv.gain.cancelScheduledValues(time);
-                sweepEnv.gain.setValueAtTime(0, time);
-                sweepEnv.gain.linearRampToValueAtTime(1, time + attackTime);
-                sweepEnv.gain.linearRampToValueAtTime(0, time + sweepLength - releaseTime);
-
-                osc.connect(sweepEnv).connect(audioCtx.destination);
-                osc.start(time);
-                osc.stop(time + sweepLength);
-           * 
-           */
           currentOsc.type = "triangle";
           currentOsc.frequency.setValueAtTime (Math.pow(this.octave, (this.offsets[i]) / this.subdivisions) * this.rootNote ,this.audioCtx.currentTime);
           currentOsc.startedAlready = false;
@@ -70,11 +55,6 @@ export default class SwitchSynth
     {
         this.oscArray.forEach(osc => 
             {
-        //this.oscArray[indexOfOscillator].connect(this.audioCtx.destination);
-
-              //osc.start();
-        //osc.connect(sweepEnv).connect(audioCtx.destination);
-
               osc.connect(this.gainArray[this.oscArray.indexOf(osc)]).connect(this.audioCtx.destination);
               osc.start(this.audioCtx.currentTime);
               this.gainArray[this.oscArray.indexOf(osc)].gain.setValueAtTime(0, this.audioCtx.currentTime);
@@ -84,10 +64,6 @@ export default class SwitchSynth
 
     connectSpecificOscillator(indexOfOscillator)
     {
-        //this.oscArray[indexOfOscillator].connect(this.audioCtx.destination);
-        
-        //osc.start(time);
-        
         this.gainArray[indexOfOscillator].gain.setValueAtTime(0, this.audioCtx.currentTime);
 
         this.gainArray[indexOfOscillator].gain.linearRampToValueAtTime(this.maxVol, this.audioCtx.currentTime + this.attackRamp);
@@ -120,9 +96,7 @@ export default class SwitchSynth
 
     disconnectSpecificOscillator(indexOfOscillator)
     {
-        //this.oscArray[indexOfOscillator].disconnect(this.audioCtx.destination);
         this.gainArray[indexOfOscillator].gain.setValueAtTime(0, this.audioCtx.currentTime);
-        //this.oscArray[indexOfOscillator].osc.stop(this.audioCtx.currentTime);
         this.oscillatorState[indexOfOscillator] = false;
     }
 
@@ -133,16 +107,6 @@ export default class SwitchSynth
         this.offsets = offsets;
         this.rootNote = rootNote;
         this.regenerateAllFrequencies();
- 
-        console.log("this.octave"); 
-        console.log(this.octave); 
-            console.log("this.subdivisions"); 
-            console.log(this.subdivisions); 
-                console.log("this.offsets"); 
-                console.log(this.offsets); 
-                    console.log("this.rootNote");
-                    console.log(this.rootNote);
-
     }
 
     regenerateAllFrequencies()

--- a/switchSynth.js
+++ b/switchSynth.js
@@ -9,6 +9,7 @@ export default class SwitchSynth
     audioCtx;
     oscArray;
     oscillatorState;     
+    noteLength;
 
     constructor(rootNote,subdivisions,offsets,octave)
     {
@@ -20,6 +21,7 @@ export default class SwitchSynth
         this.subdivisions = subdivisions;
         this.offsets = offsets;
         this.octave = octave;
+        this.noteLength = 125/1000;
     }
 
     createOscillators()
@@ -56,14 +58,20 @@ export default class SwitchSynth
     {
         this.oscArray.forEach(osc => 
             {
-              osc.start();
+        //this.oscArray[indexOfOscillator].connect(this.audioCtx.destination);
+
+              //osc.start();
+              osc.connect(this.audioCtx.destination);
             }
         );
     }
 
     connectSpecificOscillator(indexOfOscillator)
     {
-        this.oscArray[indexOfOscillator].connect(this.audioCtx.destination);
+        //this.oscArray[indexOfOscillator].connect(this.audioCtx.destination);
+        
+        //osc.start(time);
+        this.oscArray[indexOfOscillator].start(this.audioCtx.currentTime);
         this.oscillatorState[indexOfOscillator] = true;
     }
 
@@ -91,7 +99,8 @@ export default class SwitchSynth
 
     disconnectSpecificOscillator(indexOfOscillator)
     {
-        this.oscArray[indexOfOscillator].disconnect(this.audioCtx.destination);
+        //this.oscArray[indexOfOscillator].disconnect(this.audioCtx.destination);
+        this.oscArray[indexOfOscillator].osc.stop(this.audioCtx.currentTime);
         this.oscillatorState[indexOfOscillator] = false;
     }
 

--- a/switchSynth.js
+++ b/switchSynth.js
@@ -8,20 +8,28 @@ export default class SwitchSynth
     AudioContext;
     audioCtx;
     oscArray;
+    gainArray;
     oscillatorState;     
     noteLength;
+    attackRamp;
+    decaySlide;
+    maxVol;
 
-    constructor(rootNote,subdivisions,offsets,octave)
+    constructor(rootNote,subdivisions,offsets,octave,noteLength)
     {
 
         this.oscArray = [];
+        this.gainArray = [];
         this.oscillatorState = [];     
     
         this.rootNote = rootNote;
         this.subdivisions = subdivisions;
         this.offsets = offsets;
         this.octave = octave;
-        this.noteLength = 125/1000;
+        this.noteLength = noteLength/1000;
+        this.attackRamp = this.noteLength*0.4;
+        this.decaySlide = this.noteLength*0.4;
+        this.maxVol = 0.8
     }
 
     createOscillators()
@@ -50,7 +58,11 @@ export default class SwitchSynth
           currentOsc.frequency.setValueAtTime (Math.pow(this.octave, (this.offsets[i]) / this.subdivisions) * this.rootNote ,this.audioCtx.currentTime);
           currentOsc.startedAlready = false;
           this.oscArray.push(currentOsc);
-          this.oscillatorState.push(false);     
+          this.oscillatorState.push(false);   
+          const currentGain = new GainNode(this.audioCtx);
+          currentGain.gain.cancelScheduledValues(this.audioCtx.currentTime);
+          currentGain.gain.setValueAtTime(0, this.audioCtx.currentTime);
+          this.gainArray.push(currentGain);
         }
     }
 
@@ -61,7 +73,11 @@ export default class SwitchSynth
         //this.oscArray[indexOfOscillator].connect(this.audioCtx.destination);
 
               //osc.start();
-              osc.connect(this.audioCtx.destination);
+        //osc.connect(sweepEnv).connect(audioCtx.destination);
+
+              osc.connect(this.gainArray[this.oscArray.indexOf(osc)]).connect(this.audioCtx.destination);
+              osc.start(this.audioCtx.currentTime);
+              this.gainArray[this.oscArray.indexOf(osc)].gain.setValueAtTime(0, this.audioCtx.currentTime);
             }
         );
     }
@@ -71,7 +87,12 @@ export default class SwitchSynth
         //this.oscArray[indexOfOscillator].connect(this.audioCtx.destination);
         
         //osc.start(time);
-        this.oscArray[indexOfOscillator].start(this.audioCtx.currentTime);
+        
+        this.gainArray[indexOfOscillator].gain.setValueAtTime(0, this.audioCtx.currentTime);
+
+        this.gainArray[indexOfOscillator].gain.linearRampToValueAtTime(this.maxVol, this.audioCtx.currentTime + this.attackRamp);
+        this.gainArray[indexOfOscillator].gain.linearRampToValueAtTime(0, this.audioCtx.currentTime + this.noteLength - this.decaySlide);
+
         this.oscillatorState[indexOfOscillator] = true;
     }
 
@@ -100,7 +121,8 @@ export default class SwitchSynth
     disconnectSpecificOscillator(indexOfOscillator)
     {
         //this.oscArray[indexOfOscillator].disconnect(this.audioCtx.destination);
-        this.oscArray[indexOfOscillator].osc.stop(this.audioCtx.currentTime);
+        this.gainArray[indexOfOscillator].gain.setValueAtTime(0, this.audioCtx.currentTime);
+        //this.oscArray[indexOfOscillator].osc.stop(this.audioCtx.currentTime);
         this.oscillatorState[indexOfOscillator] = false;
     }
 


### PR DESCRIPTION
resolves #7 

Adds attack and decay to notes, not customisable

refactors the way grid handles notes being on and off, stopped feature where one note could be held continuously if it was on for multiple cells. 